### PR TITLE
Expose bundled contract abi path and version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 __pycache__
-__version__.py
 .coverage
 .DS_Store
 .mypy_cache

--- a/autonity/__init__.py
+++ b/autonity/__init__.py
@@ -7,7 +7,12 @@ Top-level Autonity module exposing primary types.
 # pylint: disable=unused-import
 # flake8: noqa
 
-from autonity.autonity import Autonity, AUTONITY_CONTRACT_VERSION
+from autonity.autonity import (
+    Autonity,
+    AUTONITY_CONTRACT_ADDRESS,
+    get_autonity_contract_version,
+    get_autonity_contract_abi_path,
+)
 from autonity.config import Config
 from autonity.committee_member import CommitteeMember
 from autonity.validator import ValidatorDescriptor, Validator

--- a/autonity/__version__.py
+++ b/autonity/__version__.py
@@ -1,0 +1,5 @@
+"""
+Release version of autonity package.
+"""
+
+__version__ = "v0.2.dev1"

--- a/autonity/autonity.py
+++ b/autonity/autonity.py
@@ -16,6 +16,8 @@ from autonity.committee_member import CommitteeMember, committee_member_from_tup
 from autonity.erc20 import ERC20
 from autonity.abi_manager import ABIManager
 
+import os
+
 from web3 import Web3
 from web3.contract.contract import ContractFunction
 from web3.types import ChecksumAddress, Wei, HexBytes
@@ -24,15 +26,33 @@ from typing import Sequence, TypedDict, Tuple, cast
 # pylint: disable=too-many-public-methods
 # pylint: disable=too-many-arguments
 
-AUTONITY_CONTRACT_VERSION = 2
-"""
-The version of the Autonity contract which this library is aligned
-with.
-"""
-
-
-# TODO: use the tendermint RPC call for this?
 AUTONITY_CONTRACT_ADDRESS = "0xBd770416a3345F91E4B34576cb804a576fa48EB1"
+"""
+The default autonity contract address.
+see https://docs.autonity.org/concepts/architecture/#autonity-protocol-contract
+"""
+
+
+def get_autonity_contract_version() -> str:
+    """
+    Returns the version of the Autonity contract which this library is aligned with,
+    and that is bundled with the library.
+    """
+    version_path = os.path.join(os.path.dirname(__file__), "abi", "autonity-commit.txt")
+    if not os.path.exists(version_path):
+        return "N/A"
+    with open(version_path, "r", encoding="utf-8") as file:
+        return file.read().strip()
+
+
+def get_autonity_contract_abi_path() -> str:
+    """
+    Returns the Autonity contract ABI path bundled with the library.
+    This can be used in to load the ABI from a 3rd party app or library
+    """
+    return os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "abi", "Autonity.abi")
+    )
 
 
 class Staking(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,16 +21,11 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 
-[tool.black]
-
-[tool.hatch.version]
-source = "vcs"
-
 [tool.hatch.build]
 include = ["autonity/**"]
 
-[tool.hatch.build.hooks.vcs]
-version-file = "autonity/__version__.py"
+[tool.hatch.version]
+path = "autonity/__version__.py"
 
 [metadata.hooks.vcs.urls]
 Homepage = "https://github.com/autonity/autonity.py"
@@ -45,7 +40,8 @@ dependencies = [
   "flake8==6.0.0",
   "black==23.3.0",
   "coverage==7.2.5",
-  "pyclean==2.7.0"
+  "pyclean==2.7.0",
+  "commitizen==3.2.1"
 ]
 
 [tool.hatch.envs.default.scripts]
@@ -57,15 +53,14 @@ cov-report = [
 ]
 cov = ["test-cov", "cov-report"]
 lint = [
+  "black --check autonity tests",
   "mypy autonity tests",
   "pylint autonity tests",
   "flake8 autonity tests",
-  "black --check autonity tests",
 ]
 clean = ["hatch clean", "pyclean ."]
 
 [tool.pylint]
-ignore-paths = ['autonity/__version__.py']
 good-names = ["w3", "tx"]
 disable = ["wrong-import-order", "too-few-public-methods", "fixme"]
 max-attributes = 10
@@ -83,3 +78,5 @@ exclude = "tests/archive"
 [[tool.mypy.overrides]]
 module = ["requests.*", "six"]
 ignore_missing_imports = true
+
+[tool.black]

--- a/tests/test_autonity.py
+++ b/tests/test_autonity.py
@@ -6,10 +6,59 @@ Autonity contract tests
 
 from tests.common import create_test_web3
 
-from autonity.autonity import Autonity
+from autonity.autonity import (
+    Autonity,
+    get_autonity_contract_version,
+    get_autonity_contract_abi_path,
+)
+import os
 
 from web3.types import Wei, HexBytes
 from unittest import TestCase
+
+
+class TestAutonityInfo(TestCase):
+    """
+    Test the autonity info functions.
+    """
+
+    def test_info(self) -> None:
+        """
+        Test the version function.
+        """
+        version_path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "autonity",
+                "abi",
+                "autonity-commit.txt",
+            )
+        )
+        version = get_autonity_contract_version()
+
+        with open(version_path, "r", encoding="utf-8") as file:
+            expected_version = file.read().strip()
+            self.assertIsInstance(version, str)
+            self.assertEqual(version, expected_version)
+
+        self.assertIsInstance(version, str)
+        print(f"Autonity version: {version}")
+
+    def test_abi_path(self) -> None:
+        """
+        Test the abi path function.
+        """
+
+        abs_abi_path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), "..", "autonity", "abi", "Autonity.abi"
+            )
+        )
+        abi_path = get_autonity_contract_abi_path()
+        self.assertIsInstance(abi_path, str)
+        self.assertEqual(abi_path, abs_abi_path)
+        print(f"Autonity abi path: {abi_path}")
 
 
 class TestAutonity(TestCase):


### PR DESCRIPTION
Introduces two new top level functions to access the bundled autonity contract version and path.

See #29 for more info.

To test run:
```
make test
```

