### PR TITLE
Refine CI and makefile targets 

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -22,6 +22,8 @@ jobs:
         python-version: ${{ matrix.python-ver }}
     - name: Install Hatch
       run: pip install --upgrade hatch
-    - name: Lint and test
-      run:  make check
+    - name: Lint
+      run: make lint
+    - name: Test
+      run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: check check-types check-syntax check-tests test
+.PHONY: check check-types check-syntax check-tests test coverage lint clean build publish format update-abi release-prepare
 
 check: lint test
 
@@ -15,5 +15,15 @@ coverage:
 clean:
 	hatch run clean
 
+build:
+	hatch build -t wheel
+
+publish: clean build
+	hatch publish
+
+format:
+	hatch run black autonity tests
+
 update-abi:
 	./scripts/update_abi
+


### PR DESCRIPTION
Introduces 3 new makefile targets:
- format: to format the source code
- build: to build the wheel distribution of the package
- publish: to publish the package to pypi

Separates the lint and test phase during CI: helps quickly identifying the type of error during CI execution