### PR TITLE
Support parsing json encoded input for tuple and arrays

### DIFF
--- a/autonity/abi_parser.py
+++ b/autonity/abi_parser.py
@@ -4,7 +4,6 @@
 Functions for working with contract ABIs.
 """
 
-
 from __future__ import annotations
 from web3 import Web3
 from web3.types import (
@@ -13,6 +12,7 @@ from web3.types import (
     ABIFunctionParams,
 )
 from typing import Dict, List, Tuple, Sequence, Any, Union, Callable, cast
+import json
 
 
 def find_abi_constructor(abi: ABI) -> ABIFunction:
@@ -102,17 +102,20 @@ def _parse_bool(bool_str: str) -> bool:
     return True
 
 
+def _parse_complex(value: str) -> Any:
+    """
+    Parse a complex type, such as an array or tuple.
+    """
+    return json.loads(value)
+
+
 def _string_to_argument_fn_for_type(arg_type: str) -> ParamParser:
     """
     Return a function which parses a string into a type suitable for
     function arguments.
     """
-
-    # TODO: support complex types
-
-    if "[" in arg_type:
-        raise ValueError(f"cannot convert array type '{arg_type}' from string")
-
+    if arg_type.endswith("[]") or arg_type == "tuple":
+        return _parse_complex
     if arg_type.startswith("uint") or arg_type.startswith("int"):
         return int
     if arg_type == "bool":
@@ -123,7 +126,6 @@ def _string_to_argument_fn_for_type(arg_type: str) -> ParamParser:
         return _parse_string
     if arg_type.startswith("fixed") or arg_type.startswith("ufixed"):
         return float
-
     raise ValueError(f"cannot convert '{arg_type}' from string")
 
 

--- a/tests/abi/TestTypes.abi
+++ b/tests/abi/TestTypes.abi
@@ -1,0 +1,218 @@
+[
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "x",
+				"type": "address"
+			}
+		],
+		"name": "test_address",
+		"outputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "pure",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "string[]",
+				"name": "x",
+				"type": "string[]"
+			}
+		],
+		"name": "test_array",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "pure",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "bool",
+				"name": "x",
+				"type": "bool"
+			}
+		],
+		"name": "test_bool",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "pure",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "bytes",
+				"name": "x",
+				"type": "bytes"
+			}
+		],
+		"name": "test_bytes",
+		"outputs": [
+			{
+				"internalType": "bytes",
+				"name": "",
+				"type": "bytes"
+			}
+		],
+		"stateMutability": "pure",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "string[]",
+				"name": "x",
+				"type": "string[]"
+			},
+			{
+				"components": [
+					{
+						"internalType": "address",
+						"name": "from",
+						"type": "address"
+					},
+					{
+						"internalType": "address",
+						"name": "to",
+						"type": "address"
+					},
+					{
+						"internalType": "uint256",
+						"name": "amount",
+						"type": "uint256"
+					}
+				],
+				"internalType": "struct TestTypes.Dummy",
+				"name": "y",
+				"type": "tuple"
+			},
+			{
+				"internalType": "address",
+				"name": "z",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "w",
+				"type": "uint256"
+			}
+		],
+		"name": "test_combine",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			},
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			},
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "pure",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "int256",
+				"name": "x",
+				"type": "int256"
+			}
+		],
+		"name": "test_int",
+		"outputs": [
+			{
+				"internalType": "int256",
+				"name": "",
+				"type": "int256"
+			}
+		],
+		"stateMutability": "pure",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "x",
+				"type": "string"
+			}
+		],
+		"name": "test_string",
+		"outputs": [
+			{
+				"internalType": "string",
+				"name": "",
+				"type": "string"
+			}
+		],
+		"stateMutability": "pure",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"components": [
+					{
+						"internalType": "address",
+						"name": "from",
+						"type": "address"
+					},
+					{
+						"internalType": "address",
+						"name": "to",
+						"type": "address"
+					},
+					{
+						"internalType": "uint256",
+						"name": "amount",
+						"type": "uint256"
+					}
+				],
+				"internalType": "struct TestTypes.Dummy",
+				"name": "x",
+				"type": "tuple"
+			}
+		],
+		"name": "test_tuple",
+		"outputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "pure",
+		"type": "function"
+	}
+]

--- a/tests/abi/TestTypes.sol
+++ b/tests/abi/TestTypes.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title TestTypes
+ * @dev Implements a contract to test the different types of parameters
+ */
+contract TestTypes {
+    struct Dummy {
+        address from; // if true, that person already voted
+        address to; // person delegated to
+        uint256 amount; // index of the voted proposal
+    }
+
+    function test_array(string[] calldata x) public pure returns (uint) {
+        return x.length;
+    }
+
+    function test_tuple(Dummy calldata x) public pure returns (address) {
+        return x.from;
+    }
+
+    function test_string(
+        string calldata x
+    ) public pure returns (string memory) {
+        return x;
+    }
+
+    function test_int(int x) public pure returns (int) {
+        return x;
+    }
+
+    function test_bool(bool x) public pure returns (bool) {
+        return x;
+    }
+
+    function test_address(address x) public pure returns (address) {
+        return x;
+    }
+
+    function test_bytes(bytes calldata x) public pure returns (bytes memory) {
+        return x;
+    }
+
+    function test_combine(
+        string[] calldata x,
+        Dummy calldata y,
+        address z,
+        uint256 w
+    ) public pure returns (uint, address, address, uint256) {
+        return (x.length, y.from, z, w);
+    }
+}


### PR DESCRIPTION
With this change the library is able to process tuples and arrays encoded in json format as contract call parameters.

to test run: 
```
hatch run python -m unittest -v tests/test_abi_parser.py
```

gh-18