### PR TITLE
Fix assertion error when calling the cdps getter of the Stabilization contract

### DIFF
--- a/autonity/abi_parser.py
+++ b/autonity/abi_parser.py
@@ -72,8 +72,8 @@ def parse_return_value(abi_function: ABIFunction, return_value: Any) -> Any:
             outputs[0]["type"], outputs[0], return_value
         )
 
-    assert isinstance(return_value, tuple)
-    return _parse_return_value_tuple(outputs, return_value)
+    return_value_tuple = tuple(return_value)
+    return _parse_return_value_tuple(outputs, return_value_tuple)
 
 
 ParamType = Union[str, int, float, bool]

--- a/autonity/abi_parser.py
+++ b/autonity/abi_parser.py
@@ -58,8 +58,10 @@ def parse_arguments(abi_function: ABIFunction, arguments: List[str]) -> List[Any
 
 def parse_return_value(abi_function: ABIFunction, return_value: Any) -> Any:
     """
-    Top level entry point, given the ABI outputs.  Supports void
-    types, and flattening a one-element tuple to a raw type.
+    Given the function ABI and the return values, matches the return values
+    with their names from the ABI spec.
+
+    Supports void types, and flattening a one-element tuple to a raw type.
     """
 
     outputs = abi_function["outputs"]


### PR DESCRIPTION
Fixes `AssertionError` from the

    assert isinstance(return_value, tuple)

assertion when calling the `cdps` getter of the Stabilization contract.

The reason for failing the assertion is that for this call the contract
function wrapper returns a list instead of the expected tuple.
To work around it, cast the return value to a tuple.

Note that according to web3.py docs[1], the function wrapper's call()
method "returns the return value of the executed function" i.e. there is
no guarantee that the return value is either a list or a tuple, however
I don't think we should worry about it until we run into similar errors.

[1]: https://web3py.readthedocs.io/en/stable/web3.contract.html#web3.contract.ContractFunction.call

Fixes https://github.com/autonity/autonity.py/issues/37.