### PR TITLE
Update web3.py to version 6.14.0

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -8,7 +8,7 @@ jobs:
   check:
     strategy:
       matrix:
-        python-ver: ["3.8", "3.9", "3.10", "3.11"]
+        python-ver: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-22.04, macos-latest]
 
     runs-on: ${{matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "MIT"
 keywords = ["autonity", "web3", "rpc", "client", "library"]
 dynamic = ["version"]
 requires-python = ">=3.8"
-dependencies = ["typing-extensions", "web3==6.3.0"]
+dependencies = ["typing-extensions", "web3==6.14.0"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 [project.urls]
@@ -37,7 +38,7 @@ path = "autonity/__version__.py"
 dependencies = ["mypy", "python-dotenv"]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.test.scripts]
 main = "python -m unittest discover {args:tests}"


### PR DESCRIPTION
Importing `autonity.py` on Python 3.12 fails due to

    ModuleNotFoundError: No module named 'pkg_resources'

triggered by web3.py. This is caused by web3.py's dependency on setuptools that was fixed in version 6.14.0. [1]

[1]: https://web3py.readthedocs.io/en/stable/releases.html#web3-py-v6-14-0-2024-01-10

Fixes #42 and autonity/aut#141.