### PR TITLE
Allow executing CI jobs manually

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -3,6 +3,7 @@ name: onpush
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   check:


### PR DESCRIPTION
As the tests run on the Piccadilly testnet, we might need to rerun them when the testnet is updated but there is no code modification.