### PR TITLE
Fix error in code example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ validator_ids = autonity.get_validators()
 
 # Get descriptor for the 0-th validator.  Print LNTN contract address.
 validator_desc_0 = autonity.get_validator(validator_ids[0])
-print(f"LNTN contract addr: {validator_desc_0.liquid_contract}")
+print(f"LNTN contract addr: {validator_desc_0['liquid_contract']}")
 
 # Typed validator Liquid Newton contract.  Query unclaimed fees for <ADDRESS>.
 validator_0 = Validator(w3, validator_desc_0)


### PR DESCRIPTION
`autonity.get_validator()` returns a dictionary, not an object.