### PR TITLE
Add wrappers for Liquid.lockedBalanceOf and Liquid.unlockedBalanceOf

### DIFF
--- a/autonity/erc20.py
+++ b/autonity/erc20.py
@@ -9,7 +9,7 @@ from typing import Optional, Union
 from web3 import Web3
 from web3.contract.contract import ABI, Contract, ContractFunction
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError
-from web3.types import ABIFunction, Address, ChecksumAddress
+from web3.types import ABIFunction, Address, ChecksumAddress, Wei
 
 from autonity.abi_manager import ABIManager
 
@@ -118,14 +118,14 @@ class ERC20:
         """
         return self.contract.functions.totalSupply().call()
 
-    def balance_of(self, account: ChecksumAddress) -> int:
+    def balance_of(self, account: ChecksumAddress) -> Wei:
         """
         Returns the balance of a particular address in "token units"
         (divide by 10^decimals for value in whole tokens).
         """
         return self.contract.functions.balanceOf(account).call()
 
-    def allowance(self, owner: ChecksumAddress, spender: ChecksumAddress) -> int:
+    def allowance(self, owner: ChecksumAddress, spender: ChecksumAddress) -> Wei:
         """
         Returns the quantity that `owner` has granted `spender` permission
         to spend.  Given in "token units" (divide by 10^decimals for

--- a/autonity/liquid.py
+++ b/autonity/liquid.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2015-2022 Clearmatics Technologies Ltd - All Rights Reserved.
+
+"""
+Models for the Liquid contract for a given validator.  Note
+that this contract also exposes functionality for claiming fees.
+"""
+
+from typing import Tuple
+
+from web3 import Web3
+from web3.contract.contract import ContractFunction
+from web3.types import ChecksumAddress, Wei
+
+from autonity.abi_manager import ABIManager
+from autonity.erc20 import ERC20
+
+
+class Liquid(ERC20):
+    """
+    The Liquid contract.
+
+    This is intended for internal use only. The naming mirrors
+    the Liquid contract in the Autonity code, but it's not very
+    intuitive to have methods such as "claim_rewards" on a Token.
+    Rather, this is more logically exposed by the Validator class.
+    """
+
+    def __init__(self, web3: Web3, address: ChecksumAddress):
+        super().__init__(web3, address, ABIManager.load_abi("Liquid"))
+
+    def validator(self) -> ChecksumAddress:
+        """
+        Get the validator for this contract.
+        """
+        return self.contract.functions.validator().call()
+
+    def treasury(self) -> ChecksumAddress:
+        """
+        Get the treasury for this contract.
+        """
+        return self.contract.functions.treasury().call()
+
+    def commissionRate(self) -> ChecksumAddress:
+        """
+        Get the commision rate for this contract.
+        """
+        return self.contract.functions.commissionRate().call()
+
+    def unclaimed_rewards(self, account: ChecksumAddress) -> Tuple[Wei, Wei]:
+        """
+        See `unclaimedRewards` on Liquid.sol.
+        """
+        return self.contract.functions.unclaimedRewards(account).call()
+
+    def claim_rewards(self) -> ContractFunction:
+        """
+        Create a ContractFunction to claim rewards.  Use
+        `create_contract_function_transaction` to use this in a
+        transaction.  See function `claimRewards` on LiquidNewton.sol.
+        """
+        return self.contract.functions.claimRewards()

--- a/autonity/liquid.py
+++ b/autonity/liquid.py
@@ -59,3 +59,15 @@ class Liquid(ERC20):
         transaction.  See function `claimRewards` on LiquidNewton.sol.
         """
         return self.contract.functions.claimRewards()
+
+    def locked_balance_of(self, delegator: ChecksumAddress) -> Wei:
+        """
+        See function `lockedBalanceOf` on Liquid.sol
+        """
+        return self.contract.functions.lockedBalanceOf(delegator).call()
+
+    def unlocked_balance_of(self, delegator: ChecksumAddress) -> Wei:
+        """
+        See function `unlockedBalanceOf` on Liquid.sol
+        """
+        return self.contract.functions.unlockedBalanceOf(delegator).call()

--- a/autonity/liquid_newton.py
+++ b/autonity/liquid_newton.py
@@ -1,63 +1,22 @@
 # Copyright (C) 2015-2022 Clearmatics Technologies Ltd - All Rights Reserved.
 
 """
-Models for the LiquidNewton contract for a given validator.  Note
-that this contract also exposes functionality for claiming fees.
+Deprecated module left for backwards compatibility.
 """
 
-from typing import Tuple
+import warnings
 
 from web3 import Web3
-from web3.contract.contract import ContractFunction
-from web3.types import ChecksumAddress, Wei
+from web3.types import ChecksumAddress
 
-from autonity.abi_manager import ABIManager
-from autonity.erc20 import ERC20
+from .liquid import Liquid
 
 
-class LiquidNewton(ERC20):
-    """
-    The LiquidNewton contract.
-
-    This is intended for internal use only. The naming mirrors
-    the LiquidNewton contract in the Autonity code, but it's not very
-    intuitive to have methods such as "claim_rewards" on a Token.
-    Rather, this is more logically exposed by the Validator class.
-
-    TODO: review this API (here and in the Autonity contracts).
-    """
-
+class LiquidNewton(Liquid):
     def __init__(self, web3: Web3, address: ChecksumAddress):
-        super().__init__(web3, address, ABIManager.load_abi("Liquid"))
-
-    def validator(self) -> ChecksumAddress:
-        """
-        Get the validator for this contract.
-        """
-        return self.contract.functions.validator().call()
-
-    def treasury(self) -> ChecksumAddress:
-        """
-        Get the treasury for this contract.
-        """
-        return self.contract.functions.treasury().call()
-
-    def commissionRate(self) -> ChecksumAddress:
-        """
-        Get the commision rate for this contract.
-        """
-        return self.contract.functions.commissionRate().call()
-
-    def unclaimed_rewards(self, account: ChecksumAddress) -> Tuple[Wei, Wei]:
-        """
-        See function `unclaimedRewards` on LiquidNewton.sol
-        """
-        return self.contract.functions.unclaimedRewards(account).call()
-
-    def claim_rewards(self) -> ContractFunction:
-        """
-        Create a ContractFunction to claim rewards.  Use
-        `create_contract_function_transaction` to use this in a
-        transaction.  See function `claimRewards` on LiquidNewton.sol.
-        """
-        return self.contract.functions.claimRewards()
+        warnings.warn(
+            "The liquid_newton.LiquidNewton class has been renamed to liquid.Liquid "
+            "and will be removed in a future release",
+            DeprecationWarning,
+        )
+        super().__init__(web3, address)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2015-2022 Clearmatics Technologies Ltd - All Rights Reserved.
 
 """
-LiquidNewton token tests
+Liquid contract tests
 """
 
 from unittest import TestCase
@@ -30,7 +30,7 @@ class TestValidator(TestCase):
         holders = [val.treasury for val in validators]
 
         validator = validators[0]
-        lntn = validator.lntn_contract
+        lntn = validator.liquid_contract
         lntn_symbol = lntn.symbol() or "LNTN"
         print(
             f"Validator: {validator.node_address}, {lntn_symbol}: "


### PR DESCRIPTION
Rename `LiquidNewton` to `Liquid` to reflect the change in the name of the contract and add wrapper functions for the above contract functions.

To be used in SDP automation scripts.