### PR TITLE
Fix: Add missing argument to getUnbondingReleaseState call

### DIFF
--- a/autonity/autonity.py
+++ b/autonity/autonity.py
@@ -313,7 +313,7 @@ class Autonity(ERC20):
         See `getUnbondingReleaseState` on the Autonity contract.
         """
         return UnbondingReleaseState(
-            self.contract.functions.getUnbondingReleaseState().call()
+            self.contract.functions.getUnbondingReleaseState(unbonding_id).call()
         )
 
     def get_reverting_amount(self, unbonding_id: int) -> int:

--- a/autonity/autonity.py
+++ b/autonity/autonity.py
@@ -524,7 +524,7 @@ class Autonity(ERC20):
     ) -> ContractFunction:
         """
         Set the inflation controller contract address. Restricted to the Operator
-        account.  See `setStabilizationContract` on Autonity contract.
+        account.  See `setInflationControllerContract` on Autonity contract.
         """
         return self.contract.functions.setInflationControllerContract(address)
 


### PR DESCRIPTION
`Autony.unbonding_release_state()` is raising error because of a missing contract argument.