### PR TITLE
Reduce CI duration from 20 minutes to 2 minutes

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Lint
         run: hatch run lint:check
       - name: Test
-        run: hatch run +py=${{ matrix.python-version }} test:all
+        run: hatch run +py=${{ matrix.python-ver }} test:all

--- a/tests/test_erc20.py
+++ b/tests/test_erc20.py
@@ -29,7 +29,7 @@ class TestERC20(TestCase):
         autonity = Autonity(w3)
 
         # Get some NTN holders
-        validator_addrs = autonity.get_validators()
+        validator_addrs = autonity.get_validators()[:3]
         holders = [autonity.get_validator(val)["treasury"] for val in validator_addrs]
         print(f"holders={holders}")
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -24,7 +24,7 @@ class TestValidator(TestCase):
         autonity = Autonity(w3)
 
         # Get some NTN holders
-        validator_addrs = autonity.get_validators()
+        validator_addrs = autonity.get_validators()[:3]
         validator_descs = [autonity.get_validator(val) for val in validator_addrs]
         validators = [Validator(w3, vdesc) for vdesc in validator_descs]
         holders = [val.treasury for val in validators]


### PR DESCRIPTION
At the moment CI takes ~20 minutes to complete because of the following reasons:
- The Liquid contract tests run the same commands with all 131 validators that are currently registered on the Piccadilly network.
- Because of an incorrect variable name all jobs in the matrix are executed with all Python versions.

This fix reduces CI execution time to 2 minutes.