### PR TITLE
Refactor ABI manager & resolve deprecaton warning

### DIFF
--- a/autonity/abi_manager.py
+++ b/autonity/abi_manager.py
@@ -1,10 +1,11 @@
 # Copyright (C) 2015-2022 Clearmatics Technologies Ltd - All Rights Reserved.
 
 """
-ABIManager class
+Access to bundled contract ABIs
 """
 
 import json
+import warnings
 from os import path
 from typing import Dict
 
@@ -13,27 +14,45 @@ from web3.contract.contract import ABI
 _CACHE: Dict[str, ABI] = {}
 
 
+def load_abi(contract_name: str) -> ABI:
+    """
+    Load (and cache) the ABI for a protocol contract.
+    """
+    if contract_name not in _CACHE:
+        _CACHE[contract_name] = load_abi_file(
+            path.join(path.dirname(__file__), "abi", f"{contract_name}.abi")
+        )
+
+    return _CACHE[contract_name]
+
+
+def load_abi_file(file_name: str) -> ABI:
+    """
+    Load an ABI from a file.
+    """
+    with open(file_name, "r", encoding="utf8") as abi_f:
+        return json.load(abi_f)
+
+
 class ABIManager:
     """
-    Access to bundled contract ABIs
+    Deprecated class kept for backwards compatibility.
     """
 
     @staticmethod
     def load_abi(contract_name: str) -> ABI:
-        """
-        Load (and cache) the ABI for a protocol contract.
-        """
-        if contract_name not in _CACHE:
-            _CACHE[contract_name] = ABIManager.load_abi_file(
-                path.join(path.dirname(__file__), "abi", f"{contract_name}.abi")
-            )
-
-        return _CACHE[contract_name]
+        warnings.warn(
+            "abi_manager.ABIManager.load_abi has been replaced with "
+            "abi_manager.load_abi and will be removed in a future release",
+            DeprecationWarning,
+        )
+        return load_abi(contract_name)
 
     @staticmethod
     def load_abi_file(file_name: str) -> ABI:
-        """
-        Load an ABI from a file.
-        """
-        with open(file_name, "r", encoding="utf-8") as abi_f:
-            return json.load(abi_f)
+        warnings.warn(
+            "abi_manager.ABIManager.load_abi_file has been replaced with "
+            "abi_manager.load_abi_file and will be removed in a future release",
+            DeprecationWarning,
+        )
+        return load_abi_file(file_name)

--- a/autonity/abi_manager.py
+++ b/autonity/abi_manager.py
@@ -4,13 +4,11 @@
 ABIManager class
 """
 
-import importlib.resources  # type: ignore
 import json
+from os import path
 from typing import Dict
 
 from web3.contract.contract import ABI
-
-import autonity.abi
 
 _CACHE: Dict[str, ABI] = {}
 
@@ -26,8 +24,9 @@ class ABIManager:
         Load (and cache) the ABI for a protocol contract.
         """
         if contract_name not in _CACHE:
-            text = importlib.resources.read_text(autonity.abi, contract_name + ".abi")
-            _CACHE[contract_name] = json.loads(text)
+            _CACHE[contract_name] = ABIManager.load_abi_file(
+                path.join(path.dirname(__file__), "abi", f"{contract_name}.abi")
+            )
 
         return _CACHE[contract_name]
 
@@ -36,5 +35,5 @@ class ABIManager:
         """
         Load an ABI from a file.
         """
-        with open(file_name, "r", encoding="utf8") as abi_f:
+        with open(file_name, "r", encoding="utf-8") as abi_f:
             return json.load(abi_f)

--- a/autonity/autonity.py
+++ b/autonity/autonity.py
@@ -16,7 +16,7 @@ from web3 import Web3
 from web3.contract.contract import ContractFunction
 from web3.types import Wei
 
-from autonity.abi_manager import ABIManager
+from autonity.abi_manager import load_abi
 from autonity.committee_member import CommitteeMember, committee_member_from_tuple
 from autonity.config import Config, config_from_tuple
 from autonity.erc20 import ERC20
@@ -105,7 +105,7 @@ class Autonity(ERC20):
         super().__init__(
             web3,
             web3.to_checksum_address(AUTONITY_CONTRACT_ADDRESS),
-            ABIManager.load_abi("Autonity"),
+            load_abi("Autonity"),
         )
 
         # TODO: What contract version checks can be performed here?

--- a/autonity/erc20.py
+++ b/autonity/erc20.py
@@ -11,7 +11,7 @@ from web3.contract.contract import ABI, Contract, ContractFunction
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 from web3.types import ABIFunction, Address, ChecksumAddress, Wei
 
-from autonity.abi_manager import ABIManager
+from autonity.abi_manager import load_abi
 
 # pylint: disable=too-many-arguments
 
@@ -77,7 +77,7 @@ class ERC20:
         abi: Optional[ABI] = None,
     ):
         if not abi:
-            abi = add_missing_erc20_functions(ABIManager.load_abi("IERC20"))
+            abi = add_missing_erc20_functions(load_abi("IERC20"))
         self.contract = web3.eth.contract(address, abi=abi)
 
     def name(self) -> Optional[str]:

--- a/autonity/liquid.py
+++ b/autonity/liquid.py
@@ -11,7 +11,7 @@ from web3 import Web3
 from web3.contract.contract import ContractFunction
 from web3.types import ChecksumAddress, Wei
 
-from autonity.abi_manager import ABIManager
+from autonity.abi_manager import load_abi
 from autonity.erc20 import ERC20
 
 
@@ -26,7 +26,7 @@ class Liquid(ERC20):
     """
 
     def __init__(self, web3: Web3, address: ChecksumAddress):
-        super().__init__(web3, address, ABIManager.load_abi("Liquid"))
+        super().__init__(web3, address, load_abi("Liquid"))
 
     def validator(self) -> ChecksumAddress:
         """

--- a/tests/test_abi_parser.py
+++ b/tests/test_abi_parser.py
@@ -12,7 +12,7 @@ from unittest import TestCase
 from web3 import Web3
 from web3.types import ABI
 
-from autonity.abi_manager import ABIManager
+from autonity.abi_manager import load_abi_file
 from autonity.abi_parser import find_abi_function, parse_arguments, parse_return_value
 
 MOCK_ABI = cast(
@@ -238,7 +238,7 @@ class TestABIParser(TestCase):
             },
         ]
         # execute tests
-        abi = ABIManager.load_abi_file(
+        abi = load_abi_file(
             os.path.join(os.path.dirname(__file__), "abi", "TestTypes.abi")
         )
         for test in tests:


### PR DESCRIPTION
- Resolve deprecation warning from `ABIManager.load_abi()`
- Convert static methods of the `ABIManager` class to functions