### PR TITLE
Drop "hatch-vcs" from the pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
The usage of the "hatch-vcs" plugin was dropped in 32d2830, but was still referenced in the pyproject.toml. This change removes it.