### PR TITLE
Replace the ERC20 contract binding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ gentargets = $(shell find $(SRCDIR) -name $(1).sol) $(addprefix $(ABIDIR)/$(1),.
 all: $(OUTDIR)/accountability.py \
 	 $(OUTDIR)/acu.py \
 	 $(OUTDIR)/autonity.py \
-	 $(OUTDIR)/ierc20.py \
 	 $(OUTDIR)/inflation_controller.py \
 	 $(OUTDIR)/liquid.py \
 	 $(OUTDIR)/non_stakable_vesting.py \
@@ -32,9 +31,6 @@ $(OUTDIR)/acu.py: $(call gentargets,ACU)
 
 $(OUTDIR)/autonity.py: $(call gentargets,Autonity)
 	$(call abigen,$^) --exclude computeCommittee,finalize,finalizeInitialization,updateValidatorAndTransferSlashedFunds >$@
-
-$(OUTDIR)/ierc20.py: $(call gentargets,IERC20)
-	$(call abigen,$^) >$@
 
 $(OUTDIR)/inflation_controller.py: $(call gentargets,InflationController)
 	$(call abigen,$^) >$@

--- a/autonity/__init__.py
+++ b/autonity/__init__.py
@@ -3,6 +3,7 @@
 """Package for interacting with the protocol contracts of the Autonity network."""
 
 from . import constants, contracts, networks
+from .contracts.erc20 import ERC20
 from .factory import (
     Accountability,
     ACU,
@@ -23,6 +24,7 @@ __all__ = (
     "Accountability",
     "ACU",
     "Autonity",
+    "ERC20",
     "InflationController",
     "Liquid",
     "NonStakableVesting",

--- a/autonity/contracts/erc20.py
+++ b/autonity/contracts/erc20.py
@@ -1,6 +1,6 @@
-"""IERC20 contract binding and data structures."""
+"""ERC20 contract binding and data structures."""
 
-# This module has been generated using pyabigen v0.2.9
+# This module has been generated using pyabigen v0.2.10
 
 import typing
 
@@ -8,17 +8,15 @@ import eth_typing
 import web3
 from web3.contract import base_contract, contract
 
-__version__ = "v0.14.0"
 
-
-class IERC20:
-    """IERC20 contract binding.
+class ERC20:
+    """ERC20 contract binding.
 
     Parameters
     ----------
     w3 : web3.Web3
     address : eth_typing.ChecksumAddress
-        The address of a deployed IERC20 contract.
+        The address of a deployed ERC20 contract.
     """
 
     _contract: contract.Contract
@@ -35,12 +33,12 @@ class IERC20:
 
     @property
     def Approval(self) -> typing.Type[base_contract.BaseContractEvent]:
-        """Binding for `event Approval` on the IERC20 contract."""
+        """Binding for `event Approval` on the ERC20 contract."""
         return self._contract.events.Approval
 
     @property
     def Transfer(self) -> typing.Type[base_contract.BaseContractEvent]:
-        """Binding for `event Transfer` on the IERC20 contract."""
+        """Binding for `event Transfer` on the ERC20 contract."""
         return self._contract.events.Transfer
 
     def allowance(
@@ -48,7 +46,7 @@ class IERC20:
         owner: eth_typing.ChecksumAddress,
         spender: eth_typing.ChecksumAddress,
     ) -> int:
-        """Binding for `allowance` on the IERC20 contract.
+        """Binding for `allowance` on the ERC20 contract.
 
         Parameters
         ----------
@@ -68,14 +66,14 @@ class IERC20:
     def approve(
         self,
         spender: eth_typing.ChecksumAddress,
-        amount: int,
+        value: int,
     ) -> contract.ContractFunction:
-        """Binding for `approve` on the IERC20 contract.
+        """Binding for `approve` on the ERC20 contract.
 
         Parameters
         ----------
         spender : eth_typing.ChecksumAddress
-        amount : int
+        value : int
 
         Returns
         -------
@@ -84,14 +82,14 @@ class IERC20:
         """
         return self._contract.functions.approve(
             spender,
-            amount,
+            value,
         )
 
     def balance_of(
         self,
         account: eth_typing.ChecksumAddress,
     ) -> int:
-        """Binding for `balanceOf` on the IERC20 contract.
+        """Binding for `balanceOf` on the ERC20 contract.
 
         Parameters
         ----------
@@ -106,10 +104,46 @@ class IERC20:
         ).call()
         return int(return_value)
 
+    def decimals(
+        self,
+    ) -> int:
+        """Binding for `decimals` on the ERC20 contract.
+
+        Returns
+        -------
+        int
+        """
+        return_value = self._contract.functions.decimals().call()
+        return int(return_value)
+
+    def name(
+        self,
+    ) -> str:
+        """Binding for `name` on the ERC20 contract.
+
+        Returns
+        -------
+        str
+        """
+        return_value = self._contract.functions.name().call()
+        return str(return_value)
+
+    def symbol(
+        self,
+    ) -> str:
+        """Binding for `symbol` on the ERC20 contract.
+
+        Returns
+        -------
+        str
+        """
+        return_value = self._contract.functions.symbol().call()
+        return str(return_value)
+
     def total_supply(
         self,
     ) -> int:
-        """Binding for `totalSupply` on the IERC20 contract.
+        """Binding for `totalSupply` on the ERC20 contract.
 
         Returns
         -------
@@ -120,15 +154,15 @@ class IERC20:
 
     def transfer(
         self,
-        recipient: eth_typing.ChecksumAddress,
-        amount: int,
+        to: eth_typing.ChecksumAddress,
+        value: int,
     ) -> contract.ContractFunction:
-        """Binding for `transfer` on the IERC20 contract.
+        """Binding for `transfer` on the ERC20 contract.
 
         Parameters
         ----------
-        recipient : eth_typing.ChecksumAddress
-        amount : int
+        to : eth_typing.ChecksumAddress
+        value : int
 
         Returns
         -------
@@ -136,23 +170,23 @@ class IERC20:
             A contract function instance to be sent in a transaction.
         """
         return self._contract.functions.transfer(
-            recipient,
-            amount,
+            to,
+            value,
         )
 
     def transfer_from(
         self,
-        sender: eth_typing.ChecksumAddress,
-        recipient: eth_typing.ChecksumAddress,
-        amount: int,
+        from_: eth_typing.ChecksumAddress,
+        to: eth_typing.ChecksumAddress,
+        value: int,
     ) -> contract.ContractFunction:
-        """Binding for `transferFrom` on the IERC20 contract.
+        """Binding for `transferFrom` on the ERC20 contract.
 
         Parameters
         ----------
-        sender : eth_typing.ChecksumAddress
-        recipient : eth_typing.ChecksumAddress
-        amount : int
+        from_ : eth_typing.ChecksumAddress
+        to : eth_typing.ChecksumAddress
+        value : int
 
         Returns
         -------
@@ -160,15 +194,61 @@ class IERC20:
             A contract function instance to be sent in a transaction.
         """
         return self._contract.functions.transferFrom(
-            sender,
-            recipient,
-            amount,
+            from_,
+            to,
+            value,
         )
 
 
 ABI = typing.cast(
     eth_typing.ABI,
     [
+        {
+            "inputs": [
+                {"internalType": "address", "name": "spender", "type": "address"},
+                {"internalType": "uint256", "name": "allowance", "type": "uint256"},
+                {"internalType": "uint256", "name": "needed", "type": "uint256"},
+            ],
+            "name": "ERC20InsufficientAllowance",
+            "type": "error",
+        },
+        {
+            "inputs": [
+                {"internalType": "address", "name": "sender", "type": "address"},
+                {"internalType": "uint256", "name": "balance", "type": "uint256"},
+                {"internalType": "uint256", "name": "needed", "type": "uint256"},
+            ],
+            "name": "ERC20InsufficientBalance",
+            "type": "error",
+        },
+        {
+            "inputs": [
+                {"internalType": "address", "name": "approver", "type": "address"}
+            ],
+            "name": "ERC20InvalidApprover",
+            "type": "error",
+        },
+        {
+            "inputs": [
+                {"internalType": "address", "name": "receiver", "type": "address"}
+            ],
+            "name": "ERC20InvalidReceiver",
+            "type": "error",
+        },
+        {
+            "inputs": [
+                {"internalType": "address", "name": "sender", "type": "address"}
+            ],
+            "name": "ERC20InvalidSender",
+            "type": "error",
+        },
+        {
+            "inputs": [
+                {"internalType": "address", "name": "spender", "type": "address"}
+            ],
+            "name": "ERC20InvalidSpender",
+            "type": "error",
+        },
         {
             "anonymous": False,
             "inputs": [
@@ -232,7 +312,7 @@ ABI = typing.cast(
         {
             "inputs": [
                 {"internalType": "address", "name": "spender", "type": "address"},
-                {"internalType": "uint256", "name": "amount", "type": "uint256"},
+                {"internalType": "uint256", "name": "value", "type": "uint256"},
             ],
             "name": "approve",
             "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
@@ -250,6 +330,27 @@ ABI = typing.cast(
         },
         {
             "inputs": [],
+            "name": "decimals",
+            "outputs": [{"internalType": "uint8", "name": "", "type": "uint8"}],
+            "stateMutability": "view",
+            "type": "function",
+        },
+        {
+            "inputs": [],
+            "name": "name",
+            "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+            "stateMutability": "view",
+            "type": "function",
+        },
+        {
+            "inputs": [],
+            "name": "symbol",
+            "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+            "stateMutability": "view",
+            "type": "function",
+        },
+        {
+            "inputs": [],
             "name": "totalSupply",
             "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
             "stateMutability": "view",
@@ -257,8 +358,8 @@ ABI = typing.cast(
         },
         {
             "inputs": [
-                {"internalType": "address", "name": "recipient", "type": "address"},
-                {"internalType": "uint256", "name": "amount", "type": "uint256"},
+                {"internalType": "address", "name": "to", "type": "address"},
+                {"internalType": "uint256", "name": "value", "type": "uint256"},
             ],
             "name": "transfer",
             "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
@@ -267,9 +368,9 @@ ABI = typing.cast(
         },
         {
             "inputs": [
-                {"internalType": "address", "name": "sender", "type": "address"},
-                {"internalType": "address", "name": "recipient", "type": "address"},
-                {"internalType": "uint256", "name": "amount", "type": "uint256"},
+                {"internalType": "address", "name": "from", "type": "address"},
+                {"internalType": "address", "name": "to", "type": "address"},
+                {"internalType": "uint256", "name": "value", "type": "uint256"},
             ],
             "name": "transferFrom",
             "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -12,12 +12,12 @@ from web3.contract.contract import ContractFunction
 
 import autonity
 from autonity.constants import AUTONITY_CONTRACT_ADDRESS
-from autonity.contracts import ierc20
+from autonity.contracts import erc20
 
 
 FACTORIES = [attr for attr in autonity.__dict__.values() if isinstance(attr, Callable)]
 BINDINGS = FACTORIES + [
-    ierc20.IERC20,  # IERC20 is used internally by aut-cli, not part of the public API
+    erc20.ERC20,  # ERC20 is used internally by autonity-cli, not part of the public API
 ]
 
 TEST_INPUTS = {
@@ -46,7 +46,7 @@ def pytest_generate_tests(metafunc):
             aut = autonity.Autonity(w3)
             validator = aut.get_validator(aut.get_validators()[0])
             contract = binding(w3, validator.liquid_contract)
-        elif binding.__name__ == "IERC20":
+        elif binding.__name__ == "ERC20":
             contract = binding(w3, AUTONITY_CONTRACT_ADDRESS)
         else:
             contract = binding(w3)

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -12,13 +12,9 @@ from web3.contract.contract import ContractFunction
 
 import autonity
 from autonity.constants import AUTONITY_CONTRACT_ADDRESS
-from autonity.contracts import erc20
 
 
-FACTORIES = [attr for attr in autonity.__dict__.values() if isinstance(attr, Callable)]
-BINDINGS = FACTORIES + [
-    erc20.ERC20,  # ERC20 is used internally by autonity-cli, not part of the public API
-]
+BINDINGS = [attr for attr in autonity.__dict__.values() if isinstance(attr, Callable)]
 
 TEST_INPUTS = {
     bool: True,


### PR DESCRIPTION
The contract binding that has been generated for the [IERC20 contract interface from the Autonity repository](https://github.com/autonity/autonity/blob/release/v0.14.1/autonity/solidity/contracts/interfaces/IERC20.sol) doesn't include the accessor functions for `symbol`, `name` and `decimals` that are part of the ERC20 token standard and are frequently used.

Replace the binding with one generated for [OpenZeppelin's ERC20 implementation](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.1.0/contracts/token/ERC20/ERC20.sol) instead, which includes all expected functions.

Also add the binding to the public API because it has proven to be useful when building with autonity.py outside the context of autonity-cli.