### PR TITLE
Add package overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,19 @@ pip install autonity
 
 The `autonity` package consists of the following:
 
-- [`contracts` subpackage](./autonity/contracts/): modules for protocol
-  contracts. Each module consists of the contract binding class, the contract
-  ABI, and ports of Solidity structures and enumerations.
-- [`constants` module](./autonity/constants.py): protocol parameters.
-- [`networks` module](./autonity/networks.py): parameters of the available
+- [`autonity.contracts.*`](./autonity/contracts/): Subpackage containing modules
+  for protocol contracts. Each module consists of the contract binding class,
+  the contract ABI, and ports of Solidity structures and enumerations.
+- [`autonity.constants`](./autonity/constants.py): Essential protocol parameters exposed as Python variables for convenience.
+- [`autonity.networks`](./autonity/networks.py): Connection parameters for the available
   Autonity networks.
-- [`factory` module](./autonity/factory.py): factory functions that return
+- [`autonity.factory`](./autonity/factory.py): Factory functions that return
   instances of contract binding classes. They retrieve the contract address and
-  ensure that there is no version mismatch between the contract and the bindings.
-- The functions of the `factory` module are also available as top-level
-  `autonity` module variables.
+  ensure that there is no version mismatch between the contract and the
+  bindings.
+
+For convenience, the functions of the `factory` module are also available as
+top-level `autonity` module variables.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ a virtualenv using pip or a compatible package manager:
 pip install autonity
 ```
 
+## Overview
+
+The `autonity` package consists of the following:
+
+- [`contracts` subpackage](./autonity/contracts/): modules for protocol
+  contracts. Each module consists of the contract binding class, the contract
+  ABI, and ports of Solidity structures and enumerations.
+- [`constants` module](./autonity/constants.py): protocol parameters.
+- [`networks` module](./autonity/networks.py): parameters of the available
+  Autonity networks.
+- [`factory` module](./autonity/factory.py): factory functions that return
+  instances of contract binding classes. They retrieve the contract address and
+  ensure that there is no version mismatch between the contract and the bindings.
+- The functions of the `factory` module are also available as top-level
+  `autonity` module variables.
+
 ## Usage
 
 Example usage:

--- a/autonity/constants.py
+++ b/autonity/constants.py
@@ -1,4 +1,4 @@
-"""Protocol parameters."""
+"""Essential protocol parameters exposed as Python variables for convenience."""
 
 from typing import cast
 

--- a/autonity/contracts/__init__.py
+++ b/autonity/contracts/__init__.py
@@ -1,3 +1,9 @@
+"""Subpackage containing modules for protocol contracts.
+
+Each module consists of the contract binding class, the contract ABI, and ports of
+Solidity structures and enumerations.
+"""
+
 import warnings
 
 # Suppress warnings raised by `plum` about not being able to resolve types

--- a/autonity/factory.py
+++ b/autonity/factory.py
@@ -1,5 +1,10 @@
-"""Factory functions that find the addresses of Autonity protocol contracts and return
-the contract bindings.
+"""Factory functions that return instances of contract binding classes.
+
+They retrieve the contract address and ensure that there is no version mismatch between
+the contract and the bindings.
+
+For convenience, the functions of this module are also available as top-level
+`autonity` module variables.
 """
 
 from functools import lru_cache

--- a/autonity/networks.py
+++ b/autonity/networks.py
@@ -1,4 +1,4 @@
-"""Parameters of the available Autonity networks."""
+"""Connection parameters for the available Autonity networks."""
 
 from dataclasses import dataclass
 


### PR DESCRIPTION
Add an overview of the `autonity` package that helps users get started until we have proper API documentation.