### PR TITLE
Ignore patch releases when checking protocol version

### DIFF
--- a/autonity/factory.py
+++ b/autonity/factory.py
@@ -29,26 +29,6 @@ from .contracts import (
 )
 
 
-@lru_cache()
-def _config(w3: Web3) -> autonity.Config:
-    if w3.client_version.split("/")[1] != autonity.__version__:
-        warn(
-            f"Protocol version mismatch: autonity.py {__version__} supports "
-            f"version {autonity.__version__}, the RPC node is running "
-            f"version {w3.client_version}"
-        )
-
-    config = autonity.Autonity(w3, AUTONITY_CONTRACT_ADDRESS).config()
-    if config.contract_version != AUTONITY_CONTRACT_VERSION:
-        raise RuntimeError(
-            f"Contract version mismatch: autonity.py {__version__} supports "
-            f"version {AUTONITY_CONTRACT_VERSION}, the Autonity contract is "
-            f"version {config.contract_version}"
-        )
-
-    return config
-
-
 def Accountability(w3: Web3) -> accountability.Accountability:
     """Accountability contract binding factory.
 
@@ -221,3 +201,23 @@ def UpgradeManager(w3: Web3) -> upgrade_manager.UpgradeManager:
     return upgrade_manager.UpgradeManager(
         w3, _config(w3).contracts.upgrade_manager_contract
     )
+
+
+@lru_cache()
+def _config(w3: Web3) -> autonity.Config:
+    if w3.client_version.split("/")[1] != autonity.__version__:
+        warn(
+            f"Protocol version mismatch: autonity.py {__version__} supports "
+            f"version {autonity.__version__}, the RPC node is running "
+            f"version {w3.client_version}"
+        )
+
+    config = autonity.Autonity(w3, AUTONITY_CONTRACT_ADDRESS).config()
+    if config.contract_version != AUTONITY_CONTRACT_VERSION:
+        raise RuntimeError(
+            f"Contract version mismatch: autonity.py {__version__} supports "
+            f"version {AUTONITY_CONTRACT_VERSION}, the Autonity contract is "
+            f"version {config.contract_version}"
+        )
+
+    return config

--- a/autonity/factory.py
+++ b/autonity/factory.py
@@ -206,17 +206,21 @@ def UpgradeManager(w3: Web3) -> upgrade_manager.UpgradeManager:
 
 @lru_cache()
 def _config(w3: Web3) -> autonity.Config:
-    client_version = Version.parse(w3.client_version.split("/")[1])
-    binding_version = Version.parse(autonity.__version__)
-    if (
-        client_version.major != binding_version.major
-        or client_version.minor != binding_version.minor
-    ):
-        warn(
-            f"Protocol version mismatch: autonity.py {__version__} supports "
-            f"version {autonity.__version__}, the RPC node is running "
-            f"version {w3.client_version}"
-        )
+    try:
+        client_version = Version.parse(w3.client_version.split("/")[1])
+        binding_version = Version.parse(autonity.__version__)
+    except ValueError:
+        pass
+    else:
+        if (
+            client_version.major != binding_version.major
+            or client_version.minor != binding_version.minor
+        ):
+            warn(
+                f"Protocol version mismatch: autonity.py {__version__} supports "
+                f"version {autonity.__version__}, the RPC node is running "
+                f"version {w3.client_version}"
+            )
 
     config = autonity.Autonity(w3, AUTONITY_CONTRACT_ADDRESS).config()
     if config.contract_version != AUTONITY_CONTRACT_VERSION:

--- a/autonity/factory.py
+++ b/autonity/factory.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 from warnings import warn
 
 from eth_typing import ChecksumAddress
+from semver import Version
 from web3 import Web3
 
 from .__version__ import __version__
@@ -205,7 +206,12 @@ def UpgradeManager(w3: Web3) -> upgrade_manager.UpgradeManager:
 
 @lru_cache()
 def _config(w3: Web3) -> autonity.Config:
-    if w3.client_version.split("/")[1] != autonity.__version__:
+    client_version = Version.parse(w3.client_version.split("/")[1])
+    binding_version = Version.parse(autonity.__version__)
+    if (
+        client_version.major != binding_version.major
+        or client_version.minor != binding_version.minor
+    ):
         warn(
             f"Protocol version mismatch: autonity.py {__version__} supports "
             f"version {autonity.__version__}, the RPC node is running "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "MIT"
 keywords = ["autonity", "web3", "rpc", "client", "library"]
 dynamic = ["version"]
 requires-python = ">=3.8"
-dependencies = ["web3==7.6.0", "plum-dispatch==2.5.4"]
+dependencies = ["web3==7.6.0", "plum-dispatch==2.5.4", "semver==3.0.2"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
When a contract binding is created, autonity.py checks whether the
binding matches the Autonity protocol version. This is done by comparing
the client version that the bindings were generated for with with the
client version of the RPC node, and showing a warning if the two
versions don't match.

This method of comparison may cause problems.

Firstly, it requires a new autonity.py release for every Autonity client
release even if there is no change in the contract interface.

Secondly, it is easily possible that different nodes of the network run
different patch versions of the Autonity client.

To resolve this issue, ignore the patch version when comparing version
numbers as patch releases only contain bugfixes and don't change the
contract interface.