### PR TITLE
Fix the return type & value of Accountability.events()

### DIFF
--- a/autonity/contracts/accountability.py
+++ b/autonity/contracts/accountability.py
@@ -1,6 +1,6 @@
 """Accountability contract binding and data structures."""
 
-# This module has been generated using pyabigen v0.2.11
+# This module has been generated using pyabigen v0.2.12
 
 import enum
 import typing
@@ -222,7 +222,7 @@ class Accountability:
     def events(
         self,
         key0: int,
-    ) -> Event:
+    ) -> typing.List[Event]:
         """Binding for `events` on the Accountability contract.
 
         Parameters
@@ -231,23 +231,26 @@ class Accountability:
 
         Returns
         -------
-        Event
+        typing.List[Event]
         """
         return_value = self._contract.functions.events(
             key0,
         ).call()
-        return Event(
-            EventType(return_value[0]),
-            Rule(return_value[1]),
-            eth_typing.ChecksumAddress(return_value[2]),
-            eth_typing.ChecksumAddress(return_value[3]),
-            hexbytes.HexBytes(return_value[4]),
-            int(return_value[5]),
-            int(return_value[6]),
-            int(return_value[7]),
-            int(return_value[8]),
-            int(return_value[9]),
-        )
+        return [
+            Event(
+                EventType(return_value_elem[0]),
+                Rule(return_value_elem[1]),
+                eth_typing.ChecksumAddress(return_value_elem[2]),
+                eth_typing.ChecksumAddress(return_value_elem[3]),
+                hexbytes.HexBytes(return_value_elem[4]),
+                int(return_value_elem[5]),
+                int(return_value_elem[6]),
+                int(return_value_elem[7]),
+                int(return_value_elem[8]),
+                int(return_value_elem[9]),
+            )
+            for return_value_elem in return_value
+        ]
 
     def get_validator_accusation(
         self,

--- a/autonity/contracts/acu.py
+++ b/autonity/contracts/acu.py
@@ -1,6 +1,6 @@
 """ACU contract binding and data structures."""
 
-# This module has been generated using pyabigen v0.2.11
+# This module has been generated using pyabigen v0.2.12
 
 import typing
 

--- a/autonity/contracts/autonity.py
+++ b/autonity/contracts/autonity.py
@@ -1,6 +1,6 @@
 """Autonity contract binding and data structures."""
 
-# This module has been generated using pyabigen v0.2.11
+# This module has been generated using pyabigen v0.2.12
 
 import enum
 import typing

--- a/autonity/contracts/inflation_controller.py
+++ b/autonity/contracts/inflation_controller.py
@@ -1,6 +1,6 @@
 """InflationController contract binding and data structures."""
 
-# This module has been generated using pyabigen v0.2.11
+# This module has been generated using pyabigen v0.2.12
 
 import typing
 from dataclasses import dataclass

--- a/autonity/contracts/liquid_logic.py
+++ b/autonity/contracts/liquid_logic.py
@@ -1,6 +1,6 @@
 """LiquidLogic contract binding and data structures."""
 
-# This module has been generated using pyabigen v0.2.11
+# This module has been generated using pyabigen v0.2.12
 
 import typing
 

--- a/autonity/contracts/omission_accountability.py
+++ b/autonity/contracts/omission_accountability.py
@@ -1,6 +1,6 @@
 """OmissionAccountability contract binding and data structures."""
 
-# This module has been generated using pyabigen v0.2.11
+# This module has been generated using pyabigen v0.2.12
 
 import typing
 from dataclasses import dataclass

--- a/autonity/contracts/oracle.py
+++ b/autonity/contracts/oracle.py
@@ -1,6 +1,6 @@
 """Oracle contract binding and data structures."""
 
-# This module has been generated using pyabigen v0.2.11
+# This module has been generated using pyabigen v0.2.12
 
 import typing
 from dataclasses import dataclass

--- a/autonity/contracts/stabilization.py
+++ b/autonity/contracts/stabilization.py
@@ -1,6 +1,6 @@
 """Stabilization contract binding and data structures."""
 
-# This module has been generated using pyabigen v0.2.11
+# This module has been generated using pyabigen v0.2.12
 
 import typing
 from dataclasses import dataclass

--- a/autonity/contracts/supply_control.py
+++ b/autonity/contracts/supply_control.py
@@ -1,6 +1,6 @@
 """SupplyControl contract binding and data structures."""
 
-# This module has been generated using pyabigen v0.2.11
+# This module has been generated using pyabigen v0.2.12
 
 import typing
 

--- a/autonity/contracts/upgrade_manager.py
+++ b/autonity/contracts/upgrade_manager.py
@@ -1,6 +1,6 @@
 """UpgradeManager contract binding and data structures."""
 
-# This module has been generated using pyabigen v0.2.11
+# This module has been generated using pyabigen v0.2.12
 
 import typing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ path = "autonity/__version__.py"
 
 [tool.hatch.envs.generate]
 detached = true
-dependencies = ["pyabigen@git+https://github.com/clearmatics/pyabigen@v0.2.11"]
+dependencies = ["pyabigen@git+https://github.com/clearmatics/pyabigen@v0.2.12"]
 
 [tool.hatch.envs.test]
 dependencies = ["pytest"]


### PR DESCRIPTION
Due to a bug in pyabigen that has been fixed in version 0.2.12, `Accountabilty.events()` attempted to return a single `Event` instance instead of a list of `Event`s. Calling this function resulted in an exception.